### PR TITLE
Resolving NodeJS Travis CI Issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,7 @@ node_js:
 script:
   - npm run lint
   - npm run test-and-coverage
+
+after_success:
+  - cat ./coverage/lcov.info | codacy-coverage
+  - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,20 @@
 language: node_js
 sudo: false
 node_js:
-  - "8"
-  - "7"
   - "6"
+  - "7"
+  - "8"
+  - "9"
+  - "10"
+  - "11"
+  - "node"
+
+cache: npm
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - node_js: node
 
 script:
   - npm run lint

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/Parser.js",
   "scripts": {
     "test": "lab -a code -v",
-    "test-and-coverage": "istanbul cover lab --report lcovonly -- -a code -v --timeout 10000 -l  &&  cat ./coverage/lcov.info | codacy-coverage && codecov",
+    "test-and-coverage": "istanbul cover lab --report lcovonly -- -a code -v --timeout 10000 -l",
     "lint": "eslint --quiet .",
     "precommit": "lint-staged",
     "update-applications": "node ./bin/update-applications",


### PR DESCRIPTION
Relating to bug in Travis CI causing build failures (https://github.com/WhichBrowser/Parser-JavaScript/pull/29)

* Allow failure when code coverage is not working
* De-couple code coverage from packages.json
* Add logical Node JS ordering to versions in Travis CI
* Add Node JS version 9, 10, 11, and nightly builds (nodejs)

Build changes including new PR seems to pass https://travis-ci.org/koconder/Parser-JavaScript/builds/482370762